### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The package is supported on Android API level 15 and up (Android 4.0.3 and up).
 
 ###Change log
 
+####2.2.5
+* Fixed issue where if no content type was specified, sending binary data would fail with a `NullPointerException`.
+* Fixed issue where if there was a trailing slash in the URL when creating a request, sending the request would sometimes have issues.
+
 ####2.2.4
 * Fixed an issue with the new initializer; signature remains the same.
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 ext{
-    CORE_SDK_VERSION = '2.2.4-SNAPSHOT'
+    CORE_SDK_VERSION = '2.2.5-SNAPSHOT'
 }
 
 android {

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/api/BMSClient.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/api/BMSClient.java
@@ -95,7 +95,8 @@ public class BMSClient extends AbstractClient {
 	}
 
     /**
-     *
+     * @deprecated As of release 2.2.0. if you use the new initialize methoud this function return null.
+     * Will be removed as release 3.x
      * @return backend route url
      */
     public String getBluemixAppRoute() {
@@ -103,7 +104,8 @@ public class BMSClient extends AbstractClient {
     }
 
     /**
-     *
+     * @deprecated As of release 2.2.0. if you use the new initialize methoud this function return null.
+     * Will be removed as release 3.x
      * @return backend GUID
      */
     public String getBluemixAppGUID() {

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/api/BMSClient.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/api/BMSClient.java
@@ -71,8 +71,9 @@ public class BMSClient extends AbstractClient {
 		this.backendGUID = bluemixAppGUID;
 		this.backendRoute = bluemixAppRoute;
 		this.bluemixRegionSuffix = bluemixRegion;
-		this.authorizationManager = new DummyAuthorizationManager(context);
-
+        if(null == this.authorizationManager) {
+            this.authorizationManager = new DummyAuthorizationManager(context);
+        }
 		Request.setCookieManager(cookieManager);
 		cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
 	}
@@ -88,8 +89,9 @@ public class BMSClient extends AbstractClient {
 	 */
 	public void initialize(Context context, String bluemixRegion){
 		this.bluemixRegionSuffix = bluemixRegion; // Change this if we ever support retries with multiple regions
-		this.authorizationManager = new DummyAuthorizationManager(context);
-
+        if(null == this.authorizationManager) {
+            this.authorizationManager = new DummyAuthorizationManager(context);
+        }
 		Request.setCookieManager(cookieManager);
 		cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
 	}

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/api/BMSClient.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/api/BMSClient.java
@@ -71,7 +71,7 @@ public class BMSClient extends AbstractClient {
 		this.backendGUID = bluemixAppGUID;
 		this.backendRoute = bluemixAppRoute;
 		this.bluemixRegionSuffix = bluemixRegion;
-        if(null == this.authorizationManager) {
+        if (null == this.authorizationManager) {
             this.authorizationManager = new DummyAuthorizationManager(context);
         }
 		Request.setCookieManager(cookieManager);
@@ -89,7 +89,7 @@ public class BMSClient extends AbstractClient {
 	 */
 	public void initialize(Context context, String bluemixRegion){
 		this.bluemixRegionSuffix = bluemixRegion; // Change this if we ever support retries with multiple regions
-        if(null == this.authorizationManager) {
+        if (null == this.authorizationManager) {
             this.authorizationManager = new DummyAuthorizationManager(context);
         }
 		Request.setCookieManager(cookieManager);

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/internal/BaseRequest.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/internal/BaseRequest.java
@@ -48,6 +48,7 @@ public class BaseRequest {
     public static final int DEFAULT_TIMEOUT = 60000;
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String JSON_CONTENT_TYPE = "application/json";
+    public static final String BINARY_CONTENT_TYPE = "application/octet-stream";
     public static final String TEXT_PLAIN = "text/plain";
 
     /**
@@ -340,7 +341,13 @@ public class BaseRequest {
      * @param listener The listener whose onSuccess or onFailure methods will be called when this request finishes.
      */
     protected void send(byte[] data, ResponseListener listener) {
-        RequestBody body = RequestBody.create(MediaType.parse(headers.get(CONTENT_TYPE)), data);
+        String contentType = headers.get(CONTENT_TYPE);
+
+        if (contentType == null) {
+            contentType = BINARY_CONTENT_TYPE;
+        }
+
+        RequestBody body = RequestBody.create(MediaType.parse(headers.get(contentType)), data);
 
         sendRequest(listener, body);
     }

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/internal/BaseRequest.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/core/internal/BaseRequest.java
@@ -127,7 +127,15 @@ public class BaseRequest {
             this.url = convertRelativeURLToBluemixAbsolute(url);
         }
 
+        removeTrailingSlash();
+
         setTimeout(timeout);
+    }
+
+    protected void removeTrailingSlash() {
+        if(this.url != null && this.url.endsWith("/")){
+            this.url = this.url.substring(0, this.url.length() - 1);
+        }
     }
 
     private String convertRelativeURLToBluemixAbsolute(String url) {


### PR DESCRIPTION
Hi added deprecated on getBluemixAppGUID and getBluemixRoute , so it will be more clear to users that when using the new init they cant use this methods any more.
and null check on this.authorizationManager.
